### PR TITLE
Add Config MD5 checksum

### DIFF
--- a/src/main/java/com/jerryio/publicbin/disk/AutoUpdateYamlConfigHandler.java
+++ b/src/main/java/com/jerryio/publicbin/disk/AutoUpdateYamlConfigHandler.java
@@ -30,10 +30,10 @@ public class AutoUpdateYamlConfigHandler extends BasicYamlConfigHandler {
         if (copyTemplate) {
             plugin.getDataFolder().mkdirs();
             plugin.saveResource(name, true);
+            
+            original = new FileYamlContent(plugin, name);
         }
         
-        
-        original = new FileYamlContent(plugin, name);
         if (original.config == null)
             return null;
         

--- a/src/main/java/com/jerryio/publicbin/disk/AutoUpdateYamlConfigHandler.java
+++ b/src/main/java/com/jerryio/publicbin/disk/AutoUpdateYamlConfigHandler.java
@@ -1,8 +1,11 @@
 package com.jerryio.publicbin.disk;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -11,48 +14,48 @@ import java.util.Date;
 import org.bukkit.configuration.file.YamlConfiguration;
 
 import com.jerryio.publicbin.PublicBinPlugin;
+import com.jerryio.publicbin.util.MD5Checksum;
 import com.jerryio.publicbin.util.PluginLog;
 import com.jerryio.publicbin.util.Version;
 
 public class AutoUpdateYamlConfigHandler extends BasicYamlConfigHandler {
 
     public static YamlConfiguration loadYaml(PublicBinPlugin plugin, String name) {
-        // important, in order to keep all comment messages in the file, use this method to save the default config file
-      
-        boolean ok;
-        CommentYamlConfiguration config = new CommentYamlConfiguration();
-  
-        File configFile = new File(plugin.getDataFolder(), name);
-        boolean copyTemplate = !configFile.exists();
-        
+        return AutoUpdateYamlConfigHandler.loadYaml(plugin, name, new String[] {});
+    }
+    
+    public static YamlConfiguration loadYaml(PublicBinPlugin plugin, String name, String[] forceCopyFilesMD5) {
+        FileYamlContent original = new FileYamlContent(plugin, name);
+        boolean copyTemplate = !original.file().exists();
         if (copyTemplate) {
             plugin.getDataFolder().mkdirs();
             plugin.saveResource(name, true);
         }
-          
-        ok = BasicYamlConfigHandler.loadFromFile(config, configFile);
-        if (!ok) return null;
-          
-        CommentYamlConfiguration template = new CommentYamlConfiguration();
-        ok = BasicYamlConfigHandler.loadFromInputStream(template, plugin.getResource(name));
-        if (!ok) return config; // maybe this version of the plugin do not support this file, just skip version check. 
-
+        
+        
+        original = new FileYamlContent(plugin, name);
+        if (original.config == null)
+            return null;
+        
+        
+        InputStreamYamlContent template = new InputStreamYamlContent(plugin, name);
+        if (template.config == null)
+            return original.config; // maybe this version of the plugin do not support this file, just skip version check.
+        
+        
         if (!copyTemplate) {
-            String pluginVerStr = template.getString("version", "1.0.1");
-            String configVerStr = config.getString("version", "1.0.1");
+            String pluginVerStr = template.config.getString("version", "1.0.1");
+            String configVerStr = original.config.getString("version", "1.0.1");
             Version pluginVer = new Version(pluginVerStr);
             Version configVer = new Version(configVerStr);
-              
+            
             if (pluginVer.compareTo(configVer) > 0) { // need to update the config file
                 try {
-                    PluginLog.info("Trying to update an older yaml file. File version = " + configVerStr);
+                    PluginLog.info("Trying to update file \"" + name + "\". File version = " + configVerStr);
                     
-                    backupFile(configFile);
+                    backupFile(original.file());
                       
-                    config.addDefaultsWithComments(template);
-                    config.options().copyDefaults(true);
-                    config.set("version", pluginVerStr);
-                    config.save(configFile);
+                    updateFile(original, template, forceCopyFilesMD5, pluginVerStr);
                       
                     PluginLog.info("File updated successfully.");
                 } catch (Exception ex) {
@@ -62,9 +65,8 @@ public class AutoUpdateYamlConfigHandler extends BasicYamlConfigHandler {
                 }
             }
         }
-          
         
-        return config;
+        return original.config;
     }
     
     public static File backupFile(File original) throws IOException {
@@ -75,6 +77,36 @@ public class AutoUpdateYamlConfigHandler extends BasicYamlConfigHandler {
         PluginLog.info("File backed up successfully. " + original.getName() + " --> backup/" + backup.getName());
         
         return backup;
+    }
+    
+    public static void updateFile(
+            FileYamlContent original,
+            InputStreamYamlContent template,
+            String[] forceCopyFilesMD5,
+            String version) throws Exception {
+        
+        String checksum = MD5Checksum.createStringChecksum(original.stream());
+        boolean found = false;
+        
+        for (int i = 0; i < forceCopyFilesMD5.length; i++) {
+            if (forceCopyFilesMD5[i].equals(checksum)) {
+                found = true;
+                break;
+            }
+        }
+        
+        if (found) {
+            PluginLog.info("Copying new content.");
+            
+            Files.copy(template.stream(), original.file().toPath(), StandardCopyOption.REPLACE_EXISTING);
+        } else {
+            PluginLog.info("Patching new content.");
+            
+            original.config.addDefaultsWithComments(template.config);
+            original.config.options().copyDefaults(true);
+            original.config.set("version", version);
+            original.config.save(original.file());
+        }
     }
     
     public static File getNonExistsBackupFile(File original) {
@@ -91,5 +123,45 @@ public class AutoUpdateYamlConfigHandler extends BasicYamlConfigHandler {
         while (backup.exists()) backup = new File(backupFolder, "backup " + strDate + " (" + (idx++) + ") " + name);
         
         return backup;
+    }
+    
+    private static abstract class YamlContent {
+        public CommentYamlConfiguration config;
+        public PublicBinPlugin plugin;
+        public String name;
+        
+        public YamlContent(PublicBinPlugin plugin, String name) {
+            this.plugin = plugin;
+            this.name = name;
+            this.config = new CommentYamlConfiguration();
+        }
+    }
+    
+    private static class FileYamlContent extends YamlContent {        
+        public FileYamlContent(PublicBinPlugin plugin, String name) {
+            super(plugin, name);
+            
+            if (!file().exists() || !BasicYamlConfigHandler.loadFromFile(config, file())) this.config = null;
+        }
+        
+        public File file() {
+            return new File(plugin.getDataFolder(), name);
+        }
+
+        public InputStream stream() throws Exception {
+            return new FileInputStream(file());
+        }
+    }
+    
+    private static class InputStreamYamlContent extends YamlContent {      
+        public InputStreamYamlContent(PublicBinPlugin plugin, String name) {
+            super(plugin, name);
+            
+            if (!BasicYamlConfigHandler.loadFromInputStream(config, stream())) this.config = null;
+        }
+        
+        public InputStream stream() {
+            return plugin.getResource(name);
+        }
     }
 }

--- a/src/main/java/com/jerryio/publicbin/disk/PluginSetting.java
+++ b/src/main/java/com/jerryio/publicbin/disk/PluginSetting.java
@@ -14,11 +14,15 @@ import com.jerryio.publicbin.util.I18n;
 import com.jerryio.publicbin.util.PluginLog;
 
 public class PluginSetting {
+    
+    public static final String[] OLD_CONFIG_MD5_CHECKSUMS = {
+            "1a3144fbbd4835c947010725b681e6c5"
+    };
 
     private YamlConfiguration config;
 
     public static PluginSetting load(PublicBinPlugin plugin) {
-        return new PluginSetting(AutoUpdateYamlConfigHandler.loadYaml(plugin, "config.yml"));
+        return new PluginSetting(AutoUpdateYamlConfigHandler.loadYaml(plugin, "config.yml", OLD_CONFIG_MD5_CHECKSUMS));
     }
     
     private PluginSetting(YamlConfiguration config) {

--- a/src/main/java/com/jerryio/publicbin/util/MD5Checksum.java
+++ b/src/main/java/com/jerryio/publicbin/util/MD5Checksum.java
@@ -1,0 +1,32 @@
+package com.jerryio.publicbin.util;
+
+import java.io.InputStream;
+import java.security.MessageDigest;
+
+public class MD5Checksum {
+    public static byte[] createChecksum(InputStream fis) throws Exception {
+        byte[] buffer = new byte[1024];
+        MessageDigest complete = MessageDigest.getInstance("MD5");
+        int numRead;
+
+        do {
+            numRead = fis.read(buffer);
+            if (numRead > 0) {
+                complete.update(buffer, 0, numRead);
+            }
+        } while (numRead != -1);
+
+        fis.close();
+        return complete.digest();
+    }
+
+    public static String createStringChecksum(InputStream fis) throws Exception {
+        byte[] checksum = createChecksum(fis);
+        String result = "";
+
+        for (int i = 0; i < checksum.length; i++) {
+            result += Integer.toString( ( checksum[i] & 0xff ) + 0x100, 16).substring( 1 );
+        }
+        return result;
+    }
+}

--- a/src/test/java/com/jerryio/publicbin/test/util/GeneralUtilTest.java
+++ b/src/test/java/com/jerryio/publicbin/test/util/GeneralUtilTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 
 import com.jerryio.publicbin.util.BukkitVersion;
 import com.jerryio.publicbin.util.DateTime;
+import com.jerryio.publicbin.util.MD5Checksum;
 import com.jerryio.publicbin.util.PluginLog;
 
 
@@ -22,6 +23,11 @@ public class GeneralUtilTest {
     @Test
     public void testNewDateTimeInstance() {
         new DateTime();
+    }
+    
+    @Test
+    public void testNewMD5Instance() {
+        new MD5Checksum();
     }
     
     @Test

--- a/src/test/resources/config-1.0.0.yml
+++ b/src/test/resources/config-1.0.0.yml
@@ -1,0 +1,45 @@
+# Using language, for example: en_US, zh_CN, zh_TW
+lang: en_US
+
+# The inventory mode can be...
+# - share (default, everyone using the same bin)
+# - separate (everyone has their own bin)
+mode: share
+
+# The number of rows in the bin
+size: 6
+
+# despawn after a certain amount of time
+countdown-despawn:
+  enable: true
+  # The time a set of item disappear (in seconds)
+  time: 300
+
+# Remove items when there is not much space left
+remove-when-full:
+  enable: true
+  # When the number of remaining grids is less than this number, the item will
+  # be cleared
+  threshold: 6
+  # Sort according to these principles, priority from top to bottom
+  # Item with the lower priority will be removed
+  order:
+  - metadata
+  - type
+  - durability
+  - amount
+  - time
+
+# Sort items in the bin automatically
+smart-grouping:
+  enable: true
+  # Sort according to these principles, priority from top to bottom
+  # Item with the highest priority will be placed in the first grid
+  order:
+  - type
+  - metadata
+  - durability
+  - amount
+  - time
+  
+debug: false


### PR DESCRIPTION
Using the MD5 checksum to determine whether the configuration file has been modified.

PublicBin checks whether the configuration file needs to be updated every time the server starts. If the config file needs to be updated, the plugin will check whether the config file has been modified. An unmodified version will be directly replaced with the latest version of the file. On the other hand, a modified version will be updated using the "patching" method.

